### PR TITLE
Document Version Number Gotchas

### DIFF
--- a/en/index.rst
+++ b/en/index.rst
@@ -14,3 +14,4 @@ Getting Started
   :doc:`Custom Configuration <reference/custom_configuration>` |
   :doc:`Input - Output Customization <reference/input_output_customization>` |
   :doc:`Events <reference/events>`
+  :doc:`Version Numbers <reference/version_numbers>`

--- a/en/reference/generating_migrations.rst
+++ b/en/reference/generating_migrations.rst
@@ -8,6 +8,9 @@ Migrations can be created for you if you're using the Doctrine 2 ORM or the DBAL
 `Schema Representation <http://docs.doctrine-project.org/projects/doctrine-dbal/en/latest/reference/schema-representation.html>`_.
 Empty migration classes can also be created.
 
+Favor the tools described here over manually created migration files as the library
+has some :doc:`requirements around migration version numbers <version_numbers>`.
+
 Using the ORM
 -------------
 

--- a/en/reference/generating_migrations.rst
+++ b/en/reference/generating_migrations.rst
@@ -6,6 +6,7 @@ Generating Migrations
 
 Migrations can be created for you if you're using the Doctrine 2 ORM or the DBAL
 `Schema Representation <http://docs.doctrine-project.org/projects/doctrine-dbal/en/latest/reference/schema-representation.html>`_.
+Empty migration classes can also be created.
 
 Using the ORM
 -------------
@@ -163,8 +164,8 @@ With the custom provider in place the diff command will compare the current data
 state to the one provided. If there's a mismatch, the differences will be put
 into the generated migration just like the ORM examples above.
 
-Ignoring custom Tables
-======================
+Ignoring Custom Tables
+----------------------
 
 If you have custom tables which are not managed by doctrine you might face the situation
 that with every diff task you are executing you get the remove statements for those tables
@@ -179,3 +180,13 @@ With this expression all tables prefixed with t_ will ignored by the schema tool
 If you use the DoctrineBundle with Symfony2 you can set the schema_filter option
 in your configuration. You can find more information in the documentation of the
 DoctrineMigationsBundle.
+
+Creating Empty Migrations
+-------------------------
+
+Use the ``migrations:generate`` command to create an empty migration class.
+
+.. code-block:: bash
+
+    $ ./doctrine migrations:generate
+    Generated new migration class to /path/to/migrations/DoctrineMigrations/Version20180107080000.php

--- a/en/reference/managing_migrations.rst
+++ b/en/reference/managing_migrations.rst
@@ -227,6 +227,8 @@ executed SQL outputted in a nice format:
     # Version 20100416130422
     CREATE TABLE addresses (id INT NOT NULL, street VARCHAR(255) NOT NULL, PRIMARY KEY(id)) ENGINE = InnoDB;
 
+.. _managing-versions-table:
+
 Managing the Version Table
 --------------------------
 

--- a/en/reference/version_numbers.rst
+++ b/en/reference/version_numbers.rst
@@ -1,0 +1,79 @@
+.. index::
+   single: Version Numbers
+
+Version Numbers
+===============
+
+When :doc:`Generating Migrations <generating_migrations>` the newly created
+classes are generated with the name ``Version{date}`` with ``{date}`` having a
+``YmdHis`` `format <http://php.net/manual/en/function.date.php>`_. This format
+is important as it allows the migrations to be correctly ordered.
+
+Starting with version 1.5 when loading migration classes, Doctrine Migrations
+does a ``sort($versions, SORT_STRING)`` on version numbers. This can cause
+problems with custom version numbers:
+
+.. code-block:: php
+
+    <?php
+    $versions = [
+        'Version1',
+        'Version2',
+        // ...
+        'Version10',
+    ];
+    sort($versions, SORT_STRING);
+
+    var_dump($versions);
+    /*
+    array(3) {
+      [0] =>
+      string(8) "Version1"
+      [1] =>
+      string(9) "Version10"
+      [2] =>
+      string(8) "Version2"
+    }
+    */
+
+The custom version numbers above end up out of order which may cause damage
+to a database.
+
+It's **strongly recommended** that the ``Version{date}`` migration class name
+format is kept to and that the various :doc:`tools for generating migrations <generating_migrations>`
+be used.
+
+Should some custom migration numbers be necessary, keeping the version number
+the same length as the date format (14 total characters) and padding it to the
+left with zeros should work.
+
+.. code-block:: php
+
+    <?php
+
+    $versions = [
+        'Version00000000000001',
+        'Version00000000000002',
+        // ...
+        'Version00000000000010',
+        'Version20180107070000', // generated version
+    ];
+    sort($versions, SORT_STRING);
+
+    var_dump($versions);
+    /*
+    array(4) {
+      [0] =>
+      string(21) "Version00000000000001"
+      [1] =>
+      string(21) "Version00000000000002"
+      [2] =>
+      string(21) "Version00000000000010"
+      [3] =>
+      string(21) "Version20180107070000"
+    }
+    */
+
+Please note that migrating to this new, zero-padded format may require
+:ref:`manual version table intervention <managing-versions-table>` if the
+versions have previously been applied.

--- a/en/toc.rst
+++ b/en/toc.rst
@@ -15,3 +15,4 @@ Reference Guide
    reference/custom_configuration
    reference/input_output_customization
    reference/events
+   reference/version_numbers


### PR DESCRIPTION
Should close https://github.com/doctrine/migrations/issues/516

I noted a workaround for folks that have older `Version1`, `Version2`, etc formats to make them play nice with the tool in general. Not sure if that's a good or bad idea.